### PR TITLE
Add Ferris Sweep High with a Pro Micro as the board.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ferris: cradio_left cradio_right
 cradio_left: SNIPPETS = -S zmk-usb-logging
 cradio_left cradio_right:
 	cd ${APP_DIR} && west build -d build/$@ -b nice_nano_v2 ${SNIPPETS} -- -DSHIELD=$@ -DZMK_CONFIG=${ZMK_CONFIG_DIR}/config -DZMK_EXTRA_MODULES="$(subst $(SPACE),;,$(EXTRA_MODULES))"
-	cd ${APP_DIR} && west build -d build/promicro_$@ -b sparkfun_pro_micro_rp2040 ${SNIPPETS} -- -DSHIELD=$@ -DZMK_CONFIG=${ZMK_CONFIG_DIR}/config -DZMK_EXTRA_MODULES="$(subst $(SPACE),;,$(EXTRA_MODULES))"
+	cd ${APP_DIR} && west build -d build/promicro_$@ -b sparkfun_pro_micro_rp2040 ${SNIPPETS} -- -DSHIELD=$@ -DCONFIG_MAIN_STACK_SIZE=4096 -DZMK_CONFIG=${ZMK_CONFIG_DIR}/config -DZMK_EXTRA_MODULES="$(subst $(SPACE),;,$(EXTRA_MODULES))"
 
 deploy_ferris: ferris
 	@echo -n "Put ferris_left in update mode..."

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ NANO_PATH := /media/${USER}/NICENANO
 ZERO_PATH := /media/${USER}/RPI-RP2
 
 WIN_DESKTOP := /mnt/c/Users/${USER}/Desktop
-KBD_PARTS := corne_left corne_right cradio_left cradio_right lily58_left lily58_right tern_ble weejock zaphod_lite
+KBD_PARTS := corne_left corne_right cradio_left cradio_right lily58_left lily58_right promicro_cradio_left promicro_cradio_right tern_ble weejock zaphod_lite
 
 all: corne ferris weejock tern zaphod
 
@@ -52,6 +52,7 @@ ferris: cradio_left cradio_right
 cradio_left: SNIPPETS = -S zmk-usb-logging
 cradio_left cradio_right:
 	cd ${APP_DIR} && west build -d build/$@ -b nice_nano_v2 ${SNIPPETS} -- -DSHIELD=$@ -DZMK_CONFIG=${ZMK_CONFIG_DIR}/config -DZMK_EXTRA_MODULES="$(subst $(SPACE),;,$(EXTRA_MODULES))"
+	cd ${APP_DIR} && west build -d build/promicro_$@ -b sparkfun_pro_micro_rp2040 ${SNIPPETS} -- -DSHIELD=$@ -DZMK_CONFIG=${ZMK_CONFIG_DIR}/config -DZMK_EXTRA_MODULES="$(subst $(SPACE),;,$(EXTRA_MODULES))"
 
 deploy_ferris: ferris
 	@echo -n "Put ferris_left in update mode..."

--- a/build.yaml
+++ b/build.yaml
@@ -46,3 +46,4 @@ include:
 
   - board: sparkfun_pro_micro_rp2040
     shield: cradio_left
+    cmake-args: -DCONFIG_MAIN_STACK_SIZE=4096

--- a/build.yaml
+++ b/build.yaml
@@ -43,3 +43,6 @@ include:
 
   - board: seeeduino_xiao_ble
     shield: tern_ble
+
+  - board: sparkfun_pro_micro_rp2040
+    shield: cradio_left

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -34,7 +34,7 @@ keymap {
     bindings = <
  &kp T      &kp Q &kp W &kp E &kp R        &qkp Y &qkp U &qkp I     &qkp O   &qkp P
  &kp LSHIFT &kp A &kp S &kp D &kp F        &qkp H &qkp J &qkp K     &qkp L   &qkp SEMI
- &kp LCTRL  &kp Z &kp X &kp C &tch V    &qkp N &qkp M &qkp COMMA &qkp DOT &qkp FSLH
+ &kp LCTRL  &kp Z &kp X &kp C &tch V       &qkp N &qkp M &qkp COMMA &qkp DOT &qkp FSLH
               &mo OVERLAY &kp SPACE      &qkp SPACE &to QWERTY
     >;
     display-name = "F A C";
@@ -45,12 +45,12 @@ keymap {
 // |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  |
 // |Enter|Alt-A| KP+ |Alt-T|F-Lok|   |XXXXX|XXXXX|XXXXX|XXXXX|XXXXX|
 // | Alt | ^Y  | KP- |Alt-C|M-g/r|   |XXXXX|XXXXX|XXXXX|XXXXX|XXXXX|
-// `-----------------|#####|     |   |Base |QWRTY|-----------------'
+// `-----------------|#####|KBCTL|   |     |QWRTY|-----------------'
     bindings = <
  &kp N1   &kp N2    &kp N3       &kp N4    &kp N5             &kp N6 &kp N7 &kp N8 &kp N9 &kp N0
  &kp RET  &kp LA(A) &kp KP_PLUS  &kp LA(T) &kt F              &none  &none  &none  &none  &none
  &kp LALT &kp LC(Y) &kp KP_MINUS &kp LA(C) &tth LA(G) LA(R)   &none  &none  &none  &none  &none
-                                  &trans &trans             &trans &to QWERTY
+                                  &trans &mo KEEBCTL         &trans &to QWERTY
     >;
     display-name = "T O R Y";
   };

--- a/config/west.yml
+++ b/config/west.yml
@@ -8,7 +8,7 @@ manifest:
     - name: dhruvinsh
       url-base: https://github.com/dhruvinsh
     - name: saixos
-      url-base: https://github.com/Nick-Munnich
+      url-base: https://github.com/nmunnich
     - name: amacleod
       url-base: https://github.com/amacleod
   projects:


### PR DESCRIPTION
- Add build section for Cradio driven by Pro Micro RP2040.
- Build rules in Makefile for Cradio with Pro Micro RP2040.
- Add a way to get to the keyboard control layer just from the left hand.
- Bump main stack size on the RP2040 build to 4096.
- Update Nick's remote to match the new name.
